### PR TITLE
Retry on 429 and 408 errors

### DIFF
--- a/src/client/retry.rs
+++ b/src/client/retry.rs
@@ -402,6 +402,8 @@ impl RetryableRequest {
                         let status = r.status();
                         if ctx.exhausted()
                             || !(status.is_server_error()
+                                || status == StatusCode::TOO_MANY_REQUESTS
+                                || status == StatusCode::REQUEST_TIMEOUT
                                 || (self.retry_on_conflict && status == StatusCode::CONFLICT))
                         {
                             let source = match status.is_client_error() {
@@ -586,6 +588,28 @@ mod tests {
         mock.push(
             Response::builder()
                 .status(StatusCode::BAD_GATEWAY)
+                .body(String::new())
+                .unwrap(),
+        );
+
+        let r = do_request().await.unwrap();
+        assert_eq!(r.status(), StatusCode::OK);
+
+        // Should retry 429 Too Many Requests
+        mock.push(
+            Response::builder()
+                .status(StatusCode::TOO_MANY_REQUESTS)
+                .body(String::new())
+                .unwrap(),
+        );
+
+        let r = do_request().await.unwrap();
+        assert_eq!(r.status(), StatusCode::OK);
+
+        // Should retry 408 Request Timeout
+        mock.push(
+            Response::builder()
+                .status(StatusCode::REQUEST_TIMEOUT)
                 .body(String::new())
                 .unwrap(),
         );

--- a/src/client/retry.rs
+++ b/src/client/retry.rs
@@ -402,6 +402,7 @@ impl RetryableRequest {
                         let status = r.status();
                         if ctx.exhausted()
                             || !(status.is_server_error()
+                                || status == StatusCode::TOO_MANY_REQUESTS
                                 || (self.retry_on_conflict && status == StatusCode::CONFLICT))
                         {
                             let source = match status.is_client_error() {


### PR DESCRIPTION
## Summary
- handle `StatusCode::TOO_MANY_REQUESTS` and `REQUEST_TIMEOUT` as retriable
- test that 429 and 408 responses are retried

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686aae0c85548329bbd071147fe7cf9f